### PR TITLE
users can self manage dev-news/revision-voting roles

### DIFF
--- a/commands/mod/developer-news.js
+++ b/commands/mod/developer-news.js
@@ -1,0 +1,26 @@
+const SelfRoleCommand = require('../../structures/SelfRoleCommand.js');
+
+require('dotenv').config({path: __dirname + '/.env'});
+const { DEVELOPER_NEWS } = process.env;
+
+
+module.exports = class DeveloperNewsCommand extends SelfRoleCommand {
+    constructor(client) {
+        super(client, {
+            name: 'developer-news',
+            group: 'mod',
+            aliases: ['developernews', 'dev-news', 'devnews'],
+            memberName: 'developer-news',
+            description: 'Add/Remove the `@dev-news` role to/from yourself',
+            argsPromptLimit: 0,
+            args: [
+                {
+                    key: 'action',
+                    type: 'string',
+                    prompt: '',
+                    default: 'show',
+                },
+            ],
+        }, DEVELOPER_NEWS);
+    }
+};

--- a/commands/mod/revision-voting.js
+++ b/commands/mod/revision-voting.js
@@ -1,0 +1,26 @@
+const SelfRoleCommand = require('../../structures/SelfRoleCommand.js');
+
+require('dotenv').config({path: __dirname + '/.env'});
+const { REVISION_VOTING } = process.env;
+
+
+module.exports = class RevisionVotingCommand extends SelfRoleCommand {
+    constructor(client) {
+        super(client, {
+            name: 'revision-voting',
+            group: 'mod',
+            aliases: ['revisionvoting', 'rev-voting'],
+            memberName: 'revision-voting',
+            description: 'Add/Remove the `@revision-voting` role to/from yourself',
+            argsPromptLimit: 0,
+            args: [
+                {
+                    key: 'action',
+                    type: 'string',
+                    prompt: '',
+                    default: 'show',
+                },
+            ],
+        }, REVISION_VOTING);
+    }
+};


### PR DESCRIPTION
Any user (even non-devs) can make the bot assign `@dev-news` and/or `@revision-voting` to them.

I think it won't be a problem.