### PR TITLE
WIP: !parsemem improvements

### DIFF
--- a/commands/rautil/parsemem.js
+++ b/commands/rautil/parsemem.js
@@ -41,7 +41,7 @@ const memTypes = {
 const operandRegex = 
   '(d)?(' +
   Object.keys(memSize).join('|') + 
-  ')?([0-9a-z]*)';
+  ')?([0-9a-z+-]*)';
 
 const memRegex = new RegExp(
   '(?:([' +
@@ -50,7 +50,7 @@ const memRegex = new RegExp(
   operandRegex +
   '(<=|>=|<|>|=|!=)' +
   operandRegex +
-  '(?:[(.](\\d+)[).])?', 'i');
+  '(?:[(.]([0-9a-z]+)[).])?', 'i');
 
 
 module.exports = class ParseMemCommand extends Command {

--- a/commands/rautil/parsemem.js
+++ b/commands/rautil/parsemem.js
@@ -2,6 +2,16 @@ const Command = require('../../structures/Command.js');
 
 const maxChars = 6;
 
+const finishleveln = '0xhlevel=N.1._0xhlevel=N+1_0xhlevel>d0xhlevel_R:0xhlevel<d0xhlevel';
+const templates = {
+  finishlevel: finishleveln,
+  finishlevelbeforetime: finishleveln + '_0xhtime>=T',
+  finishlevelnodeath: finishleveln + '_0xhscreen=LVLINTRO.1._R:0xhlife<d0xhlife',
+  finishlevelwithitem: finishleveln + '_0xhitem=TRUE',
+  collectitem: '0xhitem=FALSE.1._0xhitem=TRUE_R:0xhlevel!=0xhlevel',
+  changevalue: 'd:0xhaddress=v1.N._0xhaddress=v2.N._P:0xhaddress=0xhaddress'
+}
+
 const specialFlags = {
     'r': 'ResetIf',
     'p': 'PauseIf',


### PR DESCRIPTION
Implementing #27 

**Bad news:** accepting `S` as address/value breaks the parsing of it as an Alt Group starter. :disappointed: 
[related line of code](https://github.com/RetroAchievements/RABot/blob/9d19b97dcca31b4da72c432566f6dfa84323634d/commands/rautil/parsemem.js#L101)