### PR TITLE
fixes #43

### DIFF
--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -33,16 +33,22 @@ async function addMeme(reaction, user) {
     // check the messages within the fetch object to see if the message
     // that was reacted to is already in the meme-board
     const memes = fetch.find(m => {
-        typeof m.embeds[0] !=='undefined' && m.embeds[0].footer !== null  && m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(message.id)
-    }); 
-    
+        m.embeds[0] &&
+            m.embeds[0].footer &&
+            m.embeds[0].footer.text.startsWith(memoji) &&
+            m.embeds[0].footer.text.endsWith(message.id);
+    });
+
     // if the message is found within the memeboard.
     if (memes) {
         // fetch the ID of the message already on the memeboard.
         const memeMsg = await memeChannel.fetchMessage(memes.id);
 
-        if(deleteMsg)
-            return memeMsg.delete(1000);
+        if(deleteMsg) {
+            return memeMsg.delete(1000)
+                .then(msg => logger.info('Deleted a meme entry'))
+                .catch(logger.error);
+        }
 
         const memeCounter = memeRegex.exec(memes.embeds[0].footer.text);
 
@@ -121,7 +127,13 @@ async function removeMeme(reaction, user) {
         return message.channel.send(`It appears that you do not have a meme-board channel.`); 
 
     const fetchedMessages = await memeChannel.fetchMessages({ limit: MAX_MEMES });
-    const memes = fetchedMessages.find(m => typeof m.embeds[0] !=='undefined' && m.embeds[0].footer !== null  && m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(reaction.message.id));
+    const memes = fetchedMessages.find(
+        m =>
+            typeof m.embeds[0] &&
+            m.embeds[0].footer &&
+            m.embeds[0].footer.text.startsWith(memoji) &&
+            m.embeds[0].footer.text.endsWith(reaction.message.id)
+    );
     if (memes) {
         const memeCounter = memeRegex.exec(memes.embeds[0].footer.text);
         const foundMeme = memes.embeds[0];

--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -32,8 +32,10 @@ async function addMeme(reaction, user) {
 
     // check the messages within the fetch object to see if the message
     // that was reacted to is already in the meme-board
-    const memes = fetch.find(m => m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(message.id)); 
-
+    const memes = fetch.find(m => {
+        typeof m.embeds[0] !=='undefined' && m.embeds[0].footer !== null  && m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(message.id)
+    }); 
+    
     // if the message is found within the memeboard.
     if (memes) {
         // fetch the ID of the message already on the memeboard.
@@ -119,7 +121,7 @@ async function removeMeme(reaction, user) {
         return message.channel.send(`It appears that you do not have a meme-board channel.`); 
 
     const fetchedMessages = await memeChannel.fetchMessages({ limit: MAX_MEMES });
-    const memes = fetchedMessages.find(m => m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(reaction.message.id));
+    const memes = fetchedMessages.find(m => typeof m.embeds[0] !=='undefined' && m.embeds[0].footer !== null  && m.embeds[0].footer.text.startsWith(memoji) && m.embeds[0].footer.text.endsWith(reaction.message.id));
     if (memes) {
         const memeCounter = memeRegex.exec(memes.embeds[0].footer.text);
         const foundMeme = memes.embeds[0];


### PR DESCRIPTION
This pull request is for #43 wrong number in title

if i'm right the issue seems to be coming from  file and it should happen both for add and remove.
this is due to wrong check of emoji when parsing fetched memes message.

my local logs shows this error when adding / removing meme:
```
{"level":"error","time":"Thu Jan 16 2020 23:05:54 GMT+0000 (Coordinated Universal Time)","pid":11589,"hostname":"ip-172-31-27-63","msg":"Cannot read property 'text' of null","stack":"TypeError: Cannot read property 'text' of null\n    at fetch.find.m (/home/ubuntu/environment/RABot/util/MemeBoard.js:35:54)\n   at Map.find (/home/ubuntu/environment/RABot/node_modules/discord.js/src/util/Collection.js:506:11)\n    at addMeme (/home/ubuntu/environment/RABot/util/MemeBoard.js:35:25)\n    at process._tickCallback (internal/process/next_tick.js:68:7)","type":"Error","v":1}
```
...