### PR TITLE
Bugs

### DIFF
--- a/commands/util/calculator.js
+++ b/commands/util/calculator.js
@@ -22,7 +22,7 @@ module.exports = class CalculatorCommand extends Command {
 
   run(msg, { expression }) {
     try {
-      const validExpression = expression.split(',').join('.');
+      const validExpression = expression.replace(',', '.');
       return msg.say(`\`${validExpression}\` = \`${mathjs.eval(validExpression)}\``);
     } catch (err) {
       return msg.reply(`Oh no, an error occurred: \`${err.message}\`! :frowning:`);

--- a/commands/util/calculator.js
+++ b/commands/util/calculator.js
@@ -22,7 +22,8 @@ module.exports = class CalculatorCommand extends Command {
 
   run(msg, { expression }) {
     try {
-      return msg.say(`\`${expression}\` = \`${mathjs.eval(expression)}\``);
+      const validExpression = expression.split(',').join('.');
+      return msg.say(`\`${validExpression}\` = \`${mathjs.eval(validExpression)}\``);
     } catch (err) {
       return msg.reply(`Oh no, an error occurred: \`${err.message}\`! :frowning:`);
     }

--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -6,7 +6,7 @@ const logger = require('pino')({
   timestamp: () => `,"time":"${new Date()}"`,
 });
 
-const minimumReactions = 1;
+const minimumReactions = 10;
 
 const modEmoji = '🚫';
 const memoji = '🤖';

--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -149,7 +149,7 @@ async function addMeme(reaction, user) {
       // in a future update.
         .setAuthor(message.author.tag, message.author.displayAvatarURL)
         .setTimestamp(new Date())
-        .setDescription(message.cleanContent)
+        .setDescription(`${message.cleanContent}\n---\n[link](${message.url})`)
         .setFooter(`${memoji} ${reactionCounter} | ${message.id}`)
         .setImage(image)
 

--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -147,13 +147,11 @@ async function addMeme(reaction, user) {
       // At the date of this edit (31/Jan/19) embeds do not mention yet.
       // But nothing is stopping Discord from enabling mentions from embeds
       // in a future update.
-        .setTitle(message.cleanContent.substring(0,100) + '...')
         .setAuthor(message.author.tag, message.author.displayAvatarURL)
         .setTimestamp(new Date())
         .setDescription(message.cleanContent)
         .setFooter(`${memoji} ${reactionCounter} | ${message.id}`)
         .setImage(image)
-        .setURL(message.url);
 
       await memeChannel.send({ embed });
     } catch(error){

--- a/util/MemeBoard.js
+++ b/util/MemeBoard.js
@@ -6,13 +6,12 @@ const logger = require('pino')({
   timestamp: () => `,"time":"${new Date()}"`,
 });
 
-const minimumReactions = 10;
+const minimumReactions = 1;
 
 const modEmoji = '🚫';
 const memoji = '🤖';
 // regex: memoji followed by the number of votes followed '| message.id'
 const memeRegex = /^🤖\s([0-9]{1,3})\s\|\s([0-9]{17,20})/;
-
 
 function isValidReaction(reaction, user) {
   const { message } = reaction;
@@ -60,7 +59,6 @@ async function addMeme(reaction, user) {
   && m.embeds[0].footer !== null
   && m.embeds[0].footer.text.startsWith(memoji)
   && m.embeds[0].footer.text.endsWith(message.id));
-
   // if the message is found within the memeboard.
   if (memes) {
     // fetch the ID of the message already on the memeboard.
@@ -83,18 +81,23 @@ async function addMeme(reaction, user) {
 
     // the extension function checks if there is anything attached to the message.
     const image = message.attachments.size > 0 ? await extension(reaction, message.attachments.array()[0].url) : '';
+    try {
+      const embed = new RichEmbed()
+        .setColor(foundMeme.color)
+        .setTitle(foundMeme.title)
+        .setAuthor(message.author.tag, message.author.displayAvatarURL)
+        .setTimestamp()
+        .setDescription()
+        .setFooter(`${memoji} ${parseInt(memeCounter[1], 10) + 1} | ${message.id})`)
+        .setImage(image)
+        .setURL(message.url);
 
-    const embed = new RichEmbed()
-      .setColor(foundMeme.color)
-      .setTitle(foundMeme.title)
-      .setAuthor(message.author.tag, message.author.displayAvatarURL)
-      .setTimestamp()
-      .setDescription(`[link](${message.url})`)
-      .setFooter(`${memoji} ${parseInt(memeCounter[1], 10) + 1} | ${message.id}`)
-      .setImage(image);
 
-    // edit the message with the new embed
-    await memeMsg.edit({ embed });
+      // edit the message with the new embed
+      await memeMsg.edit({ embed });
+    } catch (error){
+      logger.error(error);
+    }
     return;
   }
 
@@ -134,24 +137,28 @@ async function addMeme(reaction, user) {
       message.channel.send(`${user}, you cannot meme an empty message.`);
       return;
     }
+    try {
+      const embed = new RichEmbed()
+      // nice yellow
+        .setColor(15844367)
+      // Here we use cleanContent, which replaces all mentions in the message with
+      // their equivalent text. For example, an @everyone ping will just display
+      // as @everyone, without tagging you!
+      // At the date of this edit (31/Jan/19) embeds do not mention yet.
+      // But nothing is stopping Discord from enabling mentions from embeds
+      // in a future update.
+        .setTitle(message.cleanContent.substring(0,100) + '...')
+        .setAuthor(message.author.tag, message.author.displayAvatarURL)
+        .setTimestamp(new Date())
+        .setDescription(message.cleanContent)
+        .setFooter(`${memoji} ${reactionCounter} | ${message.id}`)
+        .setImage(image)
+        .setURL(message.url);
 
-    const embed = new RichEmbed()
-    // nice yellow
-      .setColor(15844367)
-    // Here we use cleanContent, which replaces all mentions in the message with
-    // their equivalent text. For example, an @everyone ping will just display
-    // as @everyone, without tagging you!
-    // At the date of this edit (31/Jan/19) embeds do not mention yet.
-    // But nothing is stopping Discord from enabling mentions from embeds
-    // in a future update.
-      .setTitle(message.cleanContent)
-      .setAuthor(message.author.tag, message.author.displayAvatarURL)
-      .setTimestamp(new Date())
-      .setDescription(`[link](${message.url})`)
-      .setFooter(`${memoji} ${reactionCounter} | ${message.id}`)
-      .setImage(image);
-
-    await memeChannel.send({ embed });
+      await memeChannel.send({ embed });
+    } catch(error){
+      logger.error(error);
+    }
   }
 }
 


### PR DESCRIPTION
Hey @meleu, I've fixed #60 in this branch and added also a fixed for a memeboard issue presnted by @televandalist .
The problem with memeboard was:
-  The content of the memeboard was added as title. Since the title of RichEmbed only accepts 256 chars any meme text contain more would have failed to be added. I've made the following changes to memes in order to fix it:

- Title now is set as just 100 chars of the original content trailed by elipsis ...
- The content of the meme now goes in the description instead of the title
- I've also added url of the meme in the actual embed instead of in title(using setURL method:P)

