### PR TITLE
!mem Update for New Toolkit Features

### DIFF
--- a/commands/rautil/parsemem.js
+++ b/commands/rautil/parsemem.js
@@ -31,6 +31,9 @@ const specialFlags = {
   n: 'AndNext',
   o: 'OrNext',
   q: 'MeasuredIf',
+  z: 'ResetNextIf',
+  d: 'SubHits',
+  t: 'Trigger',
   '': '',
 };
 
@@ -60,11 +63,12 @@ const memTypes = {
   p: 'Prior',
   m: 'Mem',
   v: 'Value',
+  b: 'BCD',
   '': '',
 };
 
 
-const operandRegex = `(d|p)?(${
+const operandRegex = `(d|p|b)?(${
   Object.keys(memSize).join('|')
   })?([0-9a-z+-]*)`;
 
@@ -73,7 +77,7 @@ const memRegex = new RegExp(
   Object.keys(specialFlags).join('')
   }]):)?${
   operandRegex
-  }(<=|>=|<|>|=|!=)?${
+  }(<=|>=|<|>|=|!=|\\*|\\/|&|)?${
   operandRegex
   }(?:[(.]([0-9a-z]+)[).])?`,
   'i',
@@ -208,21 +212,19 @@ module.exports = class ParseMemCommand extends Command {
         }
         rMemVal = `0x${rMemVal.substring(0, maxChars + 2).padStart(maxChars, '0')}`;
 
-        if (lType !== 'd' && lType !== 'p') {
+        if (lType !== 'd' && lType !== 'p' && lType !== 'b') {
           lType = (lSize === '' || lSize === 'h') ? 'v' : 'm';
         }
-        if (rType !== 'd' && rType !== 'p') {
+        if (rType !== 'd' && rType !== 'p' && rType !== 'b') {
           rType = (rSize === '' || rSize === 'h') ? 'v' : 'm';
         }
 
         res += `\n${reqNum.toString().padStart(2, ' ')}:`;
-        res += specialFlags[flag].padEnd(10, ' ');
+        res += specialFlags[flag].padEnd(12, ' ');
         res += memTypes[lType].padEnd(6, ' ');
         res += memSize[lSize].padEnd(7, ' ');
         res += `${lMemory} `;
-        if (flag === 'A' || flag === 'B') {
-          res += '\n';
-        } else {
+        if (!((flag === 'a' || flag === 'b' || flag === 'i') && (cmp != '*' && cmp != '/' && cmp != '&'))) {
           res += cmp.padEnd(3, ' ');
           res += memTypes[rType].padEnd(6, ' ');
           res += memSize[rSize].padEnd(7, ' ');


### PR DESCRIPTION
Add support for ResetNextIf, SubHits, Trigger, BCD, and */& comparisons. Fixed issue where AddSource, SubSource and AddAddress lines still showed the second half of the comparison.

This resolved #72.


Using the same example string as https://github.com/RetroAchievements/RAWeb/pull/570
The changes in this commit using `A:0xH00b3a3_46134=0_D:d0xH00b406=0_B:p0xH00b4b5_Q:b0xH00b546=0_O:0xH00b57a=0_T:46289=0_Z:b0xH00b4f9=0_I:0xH00b578_d0xH00b4cb=224_A:0xH00fbc8*d0xH000234_B:0xH00fc59/b0xH000431_I:0xH00fc53&1` produce the following output:

```
__**Core Group**__:
 1:AddSource   Mem   8-bit  0x00b3a3 
 2:            Value        0x00b436 =  Value        0x000000  (0)
 3:SubHits     Delta 8-bit  0x00b406 =  Value        0x000000  (0)
 4:SubSource   Prior 8-bit  0x00b4b5 
 5:MeasuredIf  BCD   8-bit  0x00b546 =  Value        0x000000  (0)
 6:OrNext      Mem   8-bit  0x00b57a =  Value        0x000000  (0)
 7:Trigger     Value        0x00b4d1 =  Value        0x000000  (0)
 8:ResetNextIf BCD   8-bit  0x00b4f9 =  Value        0x000000  (0)
 9:AddAddress  Mem   8-bit  0x00b578 
10:            Delta 8-bit  0x00b4cb =  Value        0x0000e0  (0)
11:AddSource   Mem   8-bit  0x00fbc8 *  Delta 8-bit  0x000234  (0)
12:SubSource   Mem   8-bit  0x00fc59 /  BCD   8-bit  0x000431  (0)
13:AddAddress  Mem   8-bit  0x00fc53 &  Value        0x000001  (0)
```
Or viewed in Discord:
![image](https://user-images.githubusercontent.com/16140035/129112491-472dbf10-f310-42b7-9692-8a023ef68118.png)

Which match the expected results based on the RAWeb commit.
![image](https://user-images.githubusercontent.com/16140035/129112401-9afb5613-6edc-4227-873f-9dedc16d82f1.png)

