### PR TITLE
bestdays Command Fix

### DIFF
--- a/util/Utils.js
+++ b/util/Utils.js
@@ -20,7 +20,7 @@ module.exports = class Utils {
     const res = await fetch(`${url}&c=${days}`);
     const $ = cheerio.load(await res.text());
 
-    const bestDays = $('table.smalltable').find('tr').map((i, element) => ({
+    const bestDays = $('#mainpage').find('table').find('tr').map((i, element) => ({
       date: $(element).find('td:nth-of-type(1)').text().trim(),
       achievements: $(element).find('td:nth-of-type(2)').text().trim(),
       score: $(element).find('td:nth-of-type(3)').text().trim(),


### PR DESCRIPTION
Fix to the bestdays command which has apparently been broken for almost 2 years now as a result of `smalltable` being removed as the class attribute for the table in https://github.com/RetroAchievements/RAWeb/commit/a0a635559e8336ba99a21b4dc072e0cde35f6a98.

![image](https://user-images.githubusercontent.com/16140035/145901843-bf730ddd-b259-4398-9eb8-1bf96cb4f587.png)
