### PR TITLE
calc Command Fix

### DIFF
--- a/commands/util/calculator.js
+++ b/commands/util/calculator.js
@@ -23,7 +23,7 @@ module.exports = class CalculatorCommand extends Command {
   run(msg, { expression }) {
     try {
       const validExpression = expression.replace(',', '.');
-      return msg.say(`\`${validExpression}\` = \`${mathjs.eval(validExpression)}\``);
+      return msg.say(`\`${validExpression}\` = \`${mathjs.evaluate(validExpression)}\``);
     } catch (err) {
       return msg.reply(`Oh no, an error occurred: \`${err.message}\`! :frowning:`);
     }


### PR DESCRIPTION
Fix to calc command that likely broke when mathjs was updated in #79. Was getting a `math.js eval is not a function` error.

![image](https://user-images.githubusercontent.com/16140035/148141974-5c2dc62b-a3fc-4495-9a25-2e9488f6880e.png)
![image](https://user-images.githubusercontent.com/16140035/148141985-3e768701-2af8-41e2-98f7-c9287ad634bc.png)
