### PR TITLE
refactor: migrate api calls to official library

### DIFF
--- a/commands/rautil/aotw.js
+++ b/commands/rautil/aotw.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const { buildAuthorization, getAchievementOfTheWeek } = require('@retroachievements/api');
 const Command = require('../../structures/Command');
 
 const { RA_USER, RA_WEB_API_KEY } = process.env;
@@ -21,26 +21,32 @@ module.exports = class AotwCommand extends Command {
   async run(msg) {
     const max = 20;
     const sentMsg = await msg.reply(':hourglass: Getting AotW info, please wait...');
-    const apiUrl = `https://retroachievements.org/API/API_GetAchievementOfTheWeek.php?z=${RA_USER}&y=${RA_WEB_API_KEY}`;
-    fetch(apiUrl)
-      .then((res) => res.text())
-      .then((res) => {
-        const data = JSON.parse(res);
-        const achievement = data.Achievement;
-        const winners = data.Unlocks;
-        const aotwUrl = `https://retroachievements.org/achievement/${achievement.ID}`;
-        let response = `:trophy: __**Achievement of the Week**__ :trophy:\n${aotwUrl}`;
-        response += `\n\n**Recent Winners** (max ${max}, UTC time):\n`;
-        response += '```md\n';
-        winners.reverse();
-        for (let i = 0; i < max && i < winners.length; i += 1) {
-          response += `\n[${winners[i].DateAwarded}]`;
-          response += `( ${winners[i].User} ) `;
-          response += winners[i].HardcoreMode === '1' ? '<hardcore> +1' : '+0.5';
-        }
-        response += '\n```\n';
-        return sentMsg.edit(response);
-      })
-      .catch(() => sentMsg.delete());
+
+    try {
+      const authorization = buildAuthorization({
+        userName: RA_USER,
+        webApiKey: RA_WEB_API_KEY,
+      });
+      const { achievement, unlocks: winners } = await getAchievementOfTheWeek(authorization);
+
+      const aotwUrl = `https://retroachievements.org/achievement/${achievement.id}`;
+
+      let response = `:trophy: __**Achievement of the Week**__ :trophy:\n${aotwUrl}`;
+      response += `\n\n**Recent Winners** (max ${max}, UTC time):\n`;
+      response += '```md\n';
+
+      winners.reverse();
+
+      for (let i = 0; i < max && i < winners.length; i += 1) {
+        response += `\n[${winners[i].DateAwarded}]`;
+        response += `( ${winners[i].User} ) `;
+        response += winners[i].HardcoreMode === '1' ? '<hardcore> +1' : '+0.5';
+      }
+      response += '\n```\n';
+
+      return sentMsg.edit(response);
+    } catch (error) {
+      sentMsg.delete();
+    }
   }
 };

--- a/commands/rautil/aotw.js
+++ b/commands/rautil/aotw.js
@@ -38,9 +38,9 @@ module.exports = class AotwCommand extends Command {
       winners.reverse();
 
       for (let i = 0; i < max && i < winners.length; i += 1) {
-        response += `\n[${winners[i].DateAwarded}]`;
-        response += `( ${winners[i].User} ) `;
-        response += winners[i].HardcoreMode === '1' ? '<hardcore> +1' : '+0.5';
+        response += `\n[${winners[i].dateAwarded}]`;
+        response += `( ${winners[i].user} ) `;
+        response += winners[i].hardcoreMode ? '<hardcore> +1' : '+0.5';
       }
       response += '\n```\n';
 

--- a/commands/rautil/parsemem.js
+++ b/commands/rautil/parsemem.js
@@ -1,4 +1,5 @@
 const { MessageEmbed } = require('discord.js');
+const { buildAuthorization, getAchievementUnlocks } = require('@retroachievements/api');
 const fetch = require('node-fetch');
 const Command = require('../../structures/Command');
 
@@ -245,11 +246,20 @@ module.exports = class ParseMemCommand extends Command {
   }
 
   async getGameId(achievementId) {
-    const achievementUnlocksUrl = `${baseUrl}API/API_GetAchievementUnlocks.php?z=${RA_USER}&y=${RA_WEB_API_KEY}&a=${achievementId}`;
-    return fetch(achievementUnlocksUrl)
-      .then((res) => res.json())
-      .then((res) => parseInt(res.Game.ID, 10))
-      .catch(() => null);
+    const authorization = buildAuthorization({
+      userName: RA_USER,
+      webApiKey: RA_WEB_API_KEY,
+    });
+
+    try {
+      const { game } = await getAchievementUnlocks(authorization, {
+        achievementId,
+      });
+
+      return game.id;
+    } catch (error) {
+      return null;
+    }
   }
 
   async getMemAddr(gameId, achievementId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
+                "@retroachievements/api": "^1.0.0-rc.4",
                 "canvas": "^2.6.1",
                 "cheerio": "^1.0.0-rc.3",
                 "city-timezones": "^1.2.0",
@@ -199,6 +200,19 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "node_modules/@retroachievements/api": {
+            "version": "1.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0-rc.4.tgz",
+            "integrity": "sha512-hLQIn0vgX19h6xwIJE+QRdxItvdiV1Wo+GVt6B/dP2QhncPVbwX4EdXDXfsbhiRScDUBAsA/KP7IWuERPkHBZw==",
+            "dependencies": {
+                "isomorphic-unfetch": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": "please-use-yarn",
+                "yarn": ">= 1.19.1"
+            }
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -2512,6 +2526,15 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "node_modules/isomorphic-unfetch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+            "dependencies": {
+                "node-fetch": "^2.6.1",
+                "unfetch": "^4.2.0"
+            }
+        },
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -4633,6 +4656,11 @@
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true
         },
+        "node_modules/unfetch": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5019,6 +5047,14 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "@retroachievements/api": {
+            "version": "1.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0-rc.4.tgz",
+            "integrity": "sha512-hLQIn0vgX19h6xwIJE+QRdxItvdiV1Wo+GVt6B/dP2QhncPVbwX4EdXDXfsbhiRScDUBAsA/KP7IWuERPkHBZw==",
+            "requires": {
+                "isomorphic-unfetch": "^3.1.0"
+            }
         },
         "@types/json5": {
             "version": "0.0.29",
@@ -6734,6 +6770,15 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "isomorphic-unfetch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+            "requires": {
+                "node-fetch": "^2.6.1",
+                "unfetch": "^4.2.0"
+            }
+        },
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -8375,6 +8420,11 @@
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true
+        },
+        "unfetch": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
         },
         "uri-js": {
             "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
-                "@retroachievements/api": "^1.0.0-rc.4",
+                "@retroachievements/api": "^1.0.0",
                 "canvas": "^2.6.1",
                 "cheerio": "^1.0.0-rc.3",
                 "city-timezones": "^1.2.0",
@@ -202,14 +202,14 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "node_modules/@retroachievements/api": {
-            "version": "1.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0-rc.4.tgz",
-            "integrity": "sha512-hLQIn0vgX19h6xwIJE+QRdxItvdiV1Wo+GVt6B/dP2QhncPVbwX4EdXDXfsbhiRScDUBAsA/KP7IWuERPkHBZw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0.tgz",
+            "integrity": "sha512-Hp6eol0U8NWU3xuotgrAu5cop74cOjRR51dvjnsTdjHC4zGabqtH/JxJmls7kQ34eRW8W+SXR7aug4XufPUb0g==",
             "dependencies": {
                 "isomorphic-unfetch": "^3.1.0"
             },
             "engines": {
-                "node": ">=14",
+                "node": ">=16",
                 "npm": "please-use-yarn",
                 "yarn": ">= 1.19.1"
             }
@@ -5049,9 +5049,9 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "@retroachievements/api": {
-            "version": "1.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0-rc.4.tgz",
-            "integrity": "sha512-hLQIn0vgX19h6xwIJE+QRdxItvdiV1Wo+GVt6B/dP2QhncPVbwX4EdXDXfsbhiRScDUBAsA/KP7IWuERPkHBZw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-1.0.0.tgz",
+            "integrity": "sha512-Hp6eol0U8NWU3xuotgrAu5cop74cOjRR51dvjnsTdjHC4zGabqtH/JxJmls7kQ34eRW8W+SXR7aug4XufPUb0g==",
             "requires": {
                 "isomorphic-unfetch": "^3.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fix": "eslint --ignore-path .gitignore . --fix"
     },
     "dependencies": {
-        "@retroachievements/api": "^1.0.0-rc.4",
+        "@retroachievements/api": "^1.0.0",
         "canvas": "^2.6.1",
         "cheerio": "^1.0.0-rc.3",
         "city-timezones": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "redis": "^3.1.1",
         "request": "^2.88.0",
         "rss-parser": "^3.7.3",
-        "sqlite": "^4.1.2",
+        "sqlite": "^3.0.3",
         "steam-user": "^4.12.4",
         "uws": "^100.0.1",
         "youtube-search": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "fix": "eslint --ignore-path .gitignore . --fix"
     },
     "dependencies": {
+        "@retroachievements/api": "^1.0.0-rc.4",
         "canvas": "^2.6.1",
         "cheerio": "^1.0.0-rc.3",
         "city-timezones": "^1.2.0",
@@ -34,7 +35,7 @@
         "redis": "^3.1.1",
         "request": "^2.88.0",
         "rss-parser": "^3.7.3",
-        "sqlite": "^3.0.3",
+        "sqlite": "^4.1.2",
         "steam-user": "^4.12.4",
         "uws": "^100.0.1",
         "youtube-search": "^1.1.4"


### PR DESCRIPTION
This PR:
* Migrates all explicit `API_*.php` calls to RAWeb to now instead use the official JavaScript wrapper library.