### PR TITLE
feat: Update gan output code block format and coloring

### DIFF
--- a/commands/rautil/genachnews.js
+++ b/commands/rautil/genachnews.js
@@ -68,13 +68,32 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
         return date1 >= date2 ? d1 : d2;
       });
 
+      // Convert date to a human readable string based on the granularity
+      const [year, month, day] = json.Released.split('-').map(Number);
+      const date = new Date(year, month - 1, day);
+      let releaseDate = null;
+      switch (json.ReleasedAtGranularity)
+      {
+        case "day":
+          releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
+        break;
+        case "month":
+          releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
+        break;
+        case "year":
+          releaseDate = `${year}`;
+        break;
+        default:
+          releaseDate = json.Released;
+      }
+
       gameInfo = {
         id: gameId,
         title: json.Title,
         consoleName: json.ConsoleName,
         genre: json.Genre,
         developer: json.Developer,
-        releaseDate: json.Released,
+        releaseDate,
         achievementSetDate,
       };
     } catch (error) {
@@ -96,7 +115,7 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
 
     const gameInfo = await this.getGameInfo(id);
     if (!gameInfo) {
-      return sentMsg.edit(`Unable to get info from the game ID \`${id}\`... :frowning:`);
+      return sentMsg.edit(`Unable to get info from the game ID \`${id}\`... :frowning:. This command only works if the set has published achievements.`);
     }
 
     const youtubeLink = await this.getLongplayLink(
@@ -104,10 +123,13 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
     );
 
     const template = `
-\\\`\\\`\\\`md
-\`\`\`md
-< ${gameInfo.title} >
-[${gameInfo.consoleName}, ${gameInfo.genre}](${gameInfo.developer})< ${gameInfo.releaseDate} >
+\\\`\\\`\\\`ansi
+\`\`\`ansi
+Title:       [1;31m${gameInfo.title}[0m
+Console:     [0;34m${gameInfo.consoleName}[0m
+Developer:   [0;32m${gameInfo.developer}[0m
+Genre:       [0;35m${gameInfo.genre}[0m
+Released:    [0;33m${gameInfo.releaseDate}[0m
 \`\`\`\\\`\\\`\\\`
 A new set was published by @{AUTHOR_NAME} on ${gameInfo.achievementSetDate}
 ${youtubeLink || '{LONGPLAY-LINK}'}

--- a/commands/rautil/genachnews.js
+++ b/commands/rautil/genachnews.js
@@ -69,21 +69,24 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
       });
 
       // Convert date to a human readable string based on the granularity
-      const [year, month, day] = json.Released.split('-').map(Number);
-      const date = new Date(year, month - 1, day);
-      let releaseDate = null;
-      switch (json.ReleasedAtGranularity) {
-        case 'day':
-          releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
-          break;
-        case 'month':
-          releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
-          break;
-        case 'year':
-          releaseDate = `${year}`;
-          break;
-        default:
-          releaseDate = json.Released;
+      let releaseDate = '';
+      if (json.Released !== null) {
+          const [year, month, day] = json.Released.split('-').map(Number);
+          const date = new Date(year, month - 1, day);
+
+          switch (json.ReleasedAtGranularity) {
+            case 'day':
+              releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
+              break;
+            case 'month':
+              releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
+              break;
+            case 'year':
+              releaseDate = `${year}`;
+              break;
+            default:
+              releaseDate = json.Released;
+          }
       }
 
       gameInfo = {

--- a/commands/rautil/genachnews.js
+++ b/commands/rautil/genachnews.js
@@ -76,13 +76,13 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
       {
         case "day":
           releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
-        break;
+          break;
         case "month":
           releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
-        break;
+          break;
         case "year":
           releaseDate = `${year}`;
-        break;
+          break;
         default:
           releaseDate = json.Released;
       }

--- a/commands/rautil/genachnews.js
+++ b/commands/rautil/genachnews.js
@@ -72,15 +72,14 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
       const [year, month, day] = json.Released.split('-').map(Number);
       const date = new Date(year, month - 1, day);
       let releaseDate = null;
-      switch (json.ReleasedAtGranularity)
-      {
-        case "day":
+      switch (json.ReleasedAtGranularity) {
+        case 'day':
           releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
           break;
-        case "month":
+        case 'month':
           releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
           break;
-        case "year":
+        case 'year':
           releaseDate = `${year}`;
           break;
         default:

--- a/commands/rautil/genachnews.js
+++ b/commands/rautil/genachnews.js
@@ -71,22 +71,22 @@ module.exports = class GenerateAchievementNewsCommand extends Command {
       // Convert date to a human readable string based on the granularity
       let releaseDate = '';
       if (json.Released !== null) {
-          const [year, month, day] = json.Released.split('-').map(Number);
-          const date = new Date(year, month - 1, day);
+        const [year, month, day] = json.Released.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
 
-          switch (json.ReleasedAtGranularity) {
-            case 'day':
-              releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
-              break;
-            case 'month':
-              releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
-              break;
-            case 'year':
-              releaseDate = `${year}`;
-              break;
-            default:
-              releaseDate = json.Released;
-          }
+        switch (json.ReleasedAtGranularity) {
+          case 'day':
+            releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${day}, ${year}`;
+            break;
+          case 'month':
+            releaseDate = `${date.toLocaleString('en-us', { month: 'long' })} ${year}`;
+            break;
+          case 'year':
+            releaseDate = `${year}`;
+            break;
+          default:
+            releaseDate = json.Released;
+        }
       }
 
       gameInfo = {


### PR DESCRIPTION
This updates the `gan` command output to use an ansi code blocks with coloring. Tools like https://rebane2001.com/discord-colored-text-generator/ have been used to create this coloring format. This updated format is pinned in the dev Discord channel and has been commonly used when posting into the achievement news channel. The previous format used to have additional coloring, however a previous Discord update has broken that coloring.

![image](https://github.com/user-attachments/assets/1bc4fc63-e146-4340-85c8-4831aa14809c)

I've also included additional information when the command fails that it will only work if there are published achievements. This is often a common question from devs using this command for the first time.
![image](https://github.com/user-attachments/assets/95c412b0-f819-4f3d-8b17-33ee835c6d49)
